### PR TITLE
Run migrations, hydrations & deletions in order

### DIFF
--- a/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddNewPropertyToCollectionItemMigration.cs
+++ b/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddNewPropertyToCollectionItemMigration.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using Cake.DocumentDb.Attributes;
 using Newtonsoft.Json.Linq;
 

--- a/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddNewPropertyToDocumentMigrationWithLocalProfile.cs
+++ b/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddNewPropertyToDocumentMigrationWithLocalProfile.cs
@@ -3,7 +3,7 @@
 namespace Cake.DocumentDb.IntegrationTests.Migration.Migrations
 {
     [Profile("local")]
-    [Migration(201706121107)]
+    [Migration(201706121108)]
     public class AddNewPropertyToDocumentMigrationWithLocalProfile : DocumentDb.Migration.Migration
     {
         public AddNewPropertyToDocumentMigrationWithLocalProfile()

--- a/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddNewPropertyToDocumentMigrationWithRandomProfile.cs
+++ b/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddNewPropertyToDocumentMigrationWithRandomProfile.cs
@@ -3,7 +3,7 @@
 namespace Cake.DocumentDb.IntegrationTests.Migration.Migrations
 {
     [Profile("random")]
-    [Migration(201706121107)]
+    [Migration(201706121109)]
     public class AddNewPropertyToDocumentMigrationWithRandomProfile : DocumentDb.Migration.Migration
     {
         public AddNewPropertyToDocumentMigrationWithRandomProfile()

--- a/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddNewPropertyToGrandChildCollectionItemMigration.cs
+++ b/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddNewPropertyToGrandChildCollectionItemMigration.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Cake.DocumentDb.IntegrationTests.Migration.Migrations
 {
-    [Migration(201707241633)]
+    [Migration(201707241634)]
     public class AddNewPropertyToGrandChildCollectionItemMigration : DocumentDb.Migration.Migration
     {
         public AddNewPropertyToGrandChildCollectionItemMigration()

--- a/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddPropertyPopulatedFromSqlDatabaseMigrationWithLocalProfile.cs
+++ b/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddPropertyPopulatedFromSqlDatabaseMigrationWithLocalProfile.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 namespace Cake.DocumentDb.IntegrationTests.Migration.Migrations
 {
     [Profile("local")]
-    [Migration(201706121140)]
+    [Migration(201706121141)]
     public class AddPropertyPopulatedFromSqlDatabaseMigrationWithLocalProfile : SqlMigration
     {
         public AddPropertyPopulatedFromSqlDatabaseMigrationWithLocalProfile()

--- a/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddPropertyPopulatedFromSqlDatabaseMigrationWithRandomProfileWillNotMigrate.cs
+++ b/Cake.DocumentDb.IntegrationTests.Migration/Migrations/AddPropertyPopulatedFromSqlDatabaseMigrationWithRandomProfileWillNotMigrate.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 namespace Cake.DocumentDb.IntegrationTests.Migration.Migrations
 {
     [Profile("random")]
-    [Migration(201706121140)]
+    [Migration(201706121142)]
     public class AddPropertyPopulatedFromSqlDatabaseMigrationWithRandomProfileWillNotMigrate : SqlMigration
     {
         public AddPropertyPopulatedFromSqlDatabaseMigrationWithRandomProfileWillNotMigrate()

--- a/Cake.DocumentDb/Deletion/DeleteDocuments.cs
+++ b/Cake.DocumentDb/Deletion/DeleteDocuments.cs
@@ -1,10 +1,13 @@
 using System;
+using Cake.DocumentDb.Attributes;
 using Cake.DocumentDb.Deletion.Loqacious;
 
 namespace Cake.DocumentDb.Deletion
 {
     public class DeleteDocuments
     {
+        internal MigrationAttribute Attribute { get; set; }
+
         internal DeletionTask Task { get; private set; }
 
         protected void Delete(Action<DeletionConfigurationCreator> action)

--- a/Cake.DocumentDb/Hydration/SqlHydration.cs
+++ b/Cake.DocumentDb/Hydration/SqlHydration.cs
@@ -1,10 +1,13 @@
 using System;
+using Cake.DocumentDb.Attributes;
 using Cake.DocumentDb.Hydration.Loqacious;
 
 namespace Cake.DocumentDb.Hydration
 {
     public class SqlHydration
     {
+        internal MigrationAttribute Attribute { get; set; }
+
         internal SqlHydrationTask Task { get; private set; }
 
         protected void Migrate(Action<SqlHydrationConfigurationCreator> action)

--- a/Cake.DocumentDb/Migration/DocumentMigration.cs
+++ b/Cake.DocumentDb/Migration/DocumentMigration.cs
@@ -1,10 +1,13 @@
 using System;
+using Cake.DocumentDb.Attributes;
 using Cake.DocumentDb.Migration.Loqacious;
 
 namespace Cake.DocumentDb.Migration
 {
     public class DocumentMigration
     {
+        internal MigrationAttribute Attribute { get; set; }
+
         internal DocumentMigrationTask Task { get; private set; }
 
         protected void Migrate(Action<DocumentMigrationConfigurationCreator> action)

--- a/Cake.DocumentDb/Migration/Migration.cs
+++ b/Cake.DocumentDb/Migration/Migration.cs
@@ -1,10 +1,13 @@
 using System;
+using Cake.DocumentDb.Attributes;
 using Cake.DocumentDb.Migration.Loqacious;
 
 namespace Cake.DocumentDb.Migration
 {
     public class Migration
     {
+        internal MigrationAttribute Attribute { get; set; }
+
         internal MigrationTask Task { get; private set; }
 
         protected void Migrate(Action<MigrationConfigurationCreator> action)

--- a/Cake.DocumentDb/Migration/SqlMigration.cs
+++ b/Cake.DocumentDb/Migration/SqlMigration.cs
@@ -1,10 +1,13 @@
 using System;
+using Cake.DocumentDb.Attributes;
 using Cake.DocumentDb.Migration.Loqacious;
 
 namespace Cake.DocumentDb.Migration
 {
     public class SqlMigration
     {
+        internal MigrationAttribute Attribute { get; set; }
+
         internal SqlMigrationTask Task { get; private set; }
 
         protected void Migrate(Action<SqlMigrationConfigurationCreator> action)


### PR DESCRIPTION
Ensure that Migrations, Hydrations & Deletions are run in order using  the value in the migration attribute.

Deletions are valid without a migration attribute so for deletions we order by the attribute value first (and will run these in order) and then we run the run always deletions but cannot guarantee what order they will be run in as we have no specific field to order them by