### PR TITLE
Upgrading to .NET 4.6.1 and Cake.Core 0.26.0

### DIFF
--- a/Cake.DocumentDb.IntegrationTests.Collection/Cake.DocumentDb.IntegrationTests.Collection.csproj
+++ b/Cake.DocumentDb.IntegrationTests.Collection/Cake.DocumentDb.IntegrationTests.Collection.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.DocumentDb.IntegrationTests.Collection</RootNamespace>
     <AssemblyName>Cake.DocumentDb.IntegrationTests.Collection</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Cake.DocumentDb.IntegrationTests.Database/Cake.DocumentDb.IntegrationTests.Database.csproj
+++ b/Cake.DocumentDb.IntegrationTests.Database/Cake.DocumentDb.IntegrationTests.Database.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.DocumentDb.IntegrationTests.Database</RootNamespace>
     <AssemblyName>Cake.DocumentDb.IntegrationTests.Database</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Cake.DocumentDb.IntegrationTests.Deletions/Cake.DocumentDb.IntegrationTests.Deletions.csproj
+++ b/Cake.DocumentDb.IntegrationTests.Deletions/Cake.DocumentDb.IntegrationTests.Deletions.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.DocumentDb.IntegrationTests.Deletions</RootNamespace>
     <AssemblyName>Cake.DocumentDb.IntegrationTests.Deletions</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Cake.DocumentDb.IntegrationTests.Hydration/Cake.DocumentDb.IntegrationTests.Hydration.csproj
+++ b/Cake.DocumentDb.IntegrationTests.Hydration/Cake.DocumentDb.IntegrationTests.Hydration.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.DocumentDb.IntegrationTests.Hydration</RootNamespace>
     <AssemblyName>Cake.DocumentDb.IntegrationTests.Hydration</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,9 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.16.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.16.1\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Cake.Core, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.26.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Cake.DocumentDb.IntegrationTests.Hydration/packages.config
+++ b/Cake.DocumentDb.IntegrationTests.Hydration/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.16.1" targetFramework="net452" />
+  <package id="Cake.Core" version="0.26.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
 </packages>

--- a/Cake.DocumentDb.IntegrationTests.Migration/Cake.DocumentDb.IntegrationTests.Migration.csproj
+++ b/Cake.DocumentDb.IntegrationTests.Migration/Cake.DocumentDb.IntegrationTests.Migration.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.DocumentDb.IntegrationTests.Migration</RootNamespace>
     <AssemblyName>Cake.DocumentDb.IntegrationTests.Migration</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,9 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.16.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.16.1\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Cake.Core, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.26.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Cake.DocumentDb.IntegrationTests.Migration/packages.config
+++ b/Cake.DocumentDb.IntegrationTests.Migration/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.16.1" targetFramework="net452" />
+  <package id="Cake.Core" version="0.26.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
 </packages>

--- a/Cake.DocumentDb.IntegrationTests.Seed/Cake.DocumentDb.IntegrationTests.Seed.csproj
+++ b/Cake.DocumentDb.IntegrationTests.Seed/Cake.DocumentDb.IntegrationTests.Seed.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.DocumentDb.IntegrationTests.Seed</RootNamespace>
     <AssemblyName>Cake.DocumentDb.IntegrationTests.Seed</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Cake.DocumentDb/Cake.DocumentDb.csproj
+++ b/Cake.DocumentDb/Cake.DocumentDb.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.DocumentDb</RootNamespace>
     <AssemblyName>Cake.DocumentDb</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,9 +36,8 @@
     <ApplicationManifest>Cake.DocumentDb.nuspec</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.16.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.16.1\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Cake.Core, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.26.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="Dapper, Version=1.50.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Dapper.1.50.2\lib\net451\Dapper.dll</HintPath>

--- a/Cake.DocumentDb/Cake.DocumentDb.nuspec
+++ b/Cake.DocumentDb/Cake.DocumentDb.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Cake.DocumentDb</id>
-    <version>5.2.0</version>
+    <version>6.0.0</version>
     <title>$title$</title>
     <authors>jonathan.stowell</authors>
     <owners>Bud Systems Limited</owners>

--- a/Cake.DocumentDb/app.config
+++ b/Cake.DocumentDb/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/Cake.DocumentDb/packages.config
+++ b/Cake.DocumentDb/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.16.1" targetFramework="net452" />
+  <package id="Cake.Core" version="0.26.0" targetFramework="net461" />
   <package id="Dapper" version="1.50.2" targetFramework="net452" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net452" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.4" targetFramework="net452" />

--- a/collection.ps1
+++ b/collection.ps1
@@ -19,8 +19,6 @@ The build script to execute.
 The build script target to run.
 .PARAMETER Migration
 The service migrations to run.
-.PARAMETER Experimental
-Tells Cake to use the latest Roslyn release.
 .PARAMETER WhatIf
 Performs a dry run of the build script.
 No tasks will be executed.
@@ -40,7 +38,6 @@ http://cakebuild.net
 Param(
     [string]$Script = "collection.cake",
     [string]$Target = "Default",
-    [switch]$Experimental,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,
     [switch]$Mono,
@@ -92,13 +89,6 @@ $UseMono = "";
 if($Mono.IsPresent) {
     Write-Verbose -Message "Using the Mono based scripting engine."
     $UseMono = "-mono"
-}
-
-# Should we use the new Roslyn?
-$UseExperimental = "";
-if($Experimental.IsPresent -and !($Mono.IsPresent)) {
-    Write-Verbose -Message "Using experimental version of Roslyn."
-    $UseExperimental = "-experimental"
 }
 
 # Is this a dry run?
@@ -177,7 +167,7 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
-# Start Cake - we use the experimental flag to support functionality such as string interpolation
+# Start Cake.
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun -experimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun $ScriptArgs"
 exit $LASTEXITCODE

--- a/database.ps1
+++ b/database.ps1
@@ -19,8 +19,6 @@ The build script to execute.
 The build script target to run.
 .PARAMETER Migration
 The service migrations to run.
-.PARAMETER Experimental
-Tells Cake to use the latest Roslyn release.
 .PARAMETER WhatIf
 Performs a dry run of the build script.
 No tasks will be executed.
@@ -40,7 +38,6 @@ http://cakebuild.net
 Param(
     [string]$Script = "database.cake",
     [string]$Target = "Default",
-    [switch]$Experimental,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,
     [switch]$Mono,
@@ -92,13 +89,6 @@ $UseMono = "";
 if($Mono.IsPresent) {
     Write-Verbose -Message "Using the Mono based scripting engine."
     $UseMono = "-mono"
-}
-
-# Should we use the new Roslyn?
-$UseExperimental = "";
-if($Experimental.IsPresent -and !($Mono.IsPresent)) {
-    Write-Verbose -Message "Using experimental version of Roslyn."
-    $UseExperimental = "-experimental"
 }
 
 # Is this a dry run?
@@ -177,7 +167,7 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
-# Start Cake - we use the experimental flag to support functionality such as string interpolation
+# Start Cake.
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun -experimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun $ScriptArgs"
 exit $LASTEXITCODE

--- a/deletions.ps1
+++ b/deletions.ps1
@@ -19,8 +19,6 @@ The build script to execute.
 The build script target to run.
 .PARAMETER Migration
 The service migrations to run.
-.PARAMETER Experimental
-Tells Cake to use the latest Roslyn release.
 .PARAMETER WhatIf
 Performs a dry run of the build script.
 No tasks will be executed.
@@ -40,7 +38,6 @@ http://cakebuild.net
 Param(
     [string]$Script = "deletions.cake",
     [string]$Target = "Default",
-    [switch]$Experimental,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,
     [switch]$Mono,
@@ -92,13 +89,6 @@ $UseMono = "";
 if($Mono.IsPresent) {
     Write-Verbose -Message "Using the Mono based scripting engine."
     $UseMono = "-mono"
-}
-
-# Should we use the new Roslyn?
-$UseExperimental = "";
-if($Experimental.IsPresent -and !($Mono.IsPresent)) {
-    Write-Verbose -Message "Using experimental version of Roslyn."
-    $UseExperimental = "-experimental"
 }
 
 # Is this a dry run?
@@ -177,7 +167,7 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
-# Start Cake - we use the experimental flag to support functionality such as string interpolation
+# Start Cake.
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun -experimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun $ScriptArgs"
 exit $LASTEXITCODE

--- a/hydration.ps1
+++ b/hydration.ps1
@@ -19,8 +19,6 @@ The build script to execute.
 The build script target to run.
 .PARAMETER Migration
 The service migrations to run.
-.PARAMETER Experimental
-Tells Cake to use the latest Roslyn release.
 .PARAMETER WhatIf
 Performs a dry run of the build script.
 No tasks will be executed.
@@ -40,7 +38,6 @@ http://cakebuild.net
 Param(
     [string]$Script = "hydration.cake",
     [string]$Target = "Default",
-    [switch]$Experimental,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,
     [switch]$Mono,
@@ -92,13 +89,6 @@ $UseMono = "";
 if($Mono.IsPresent) {
     Write-Verbose -Message "Using the Mono based scripting engine."
     $UseMono = "-mono"
-}
-
-# Should we use the new Roslyn?
-$UseExperimental = "";
-if($Experimental.IsPresent -and !($Mono.IsPresent)) {
-    Write-Verbose -Message "Using experimental version of Roslyn."
-    $UseExperimental = "-experimental"
 }
 
 # Is this a dry run?
@@ -177,7 +167,7 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
-# Start Cake - we use the experimental flag to support functionality such as string interpolation
+# Start Cake.
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun -experimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun $ScriptArgs"
 exit $LASTEXITCODE

--- a/migration.ps1
+++ b/migration.ps1
@@ -19,8 +19,6 @@ The build script to execute.
 The build script target to run.
 .PARAMETER Migration
 The service migrations to run.
-.PARAMETER Experimental
-Tells Cake to use the latest Roslyn release.
 .PARAMETER WhatIf
 Performs a dry run of the build script.
 No tasks will be executed.
@@ -40,7 +38,6 @@ http://cakebuild.net
 Param(
     [string]$Script = "migration.cake",
     [string]$Target = "Default",
-    [switch]$Experimental,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,
     [switch]$Mono,
@@ -92,13 +89,6 @@ $UseMono = "";
 if($Mono.IsPresent) {
     Write-Verbose -Message "Using the Mono based scripting engine."
     $UseMono = "-mono"
-}
-
-# Should we use the new Roslyn?
-$UseExperimental = "";
-if($Experimental.IsPresent -and !($Mono.IsPresent)) {
-    Write-Verbose -Message "Using experimental version of Roslyn."
-    $UseExperimental = "-experimental"
 }
 
 # Is this a dry run?
@@ -177,7 +167,7 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
-# Start Cake - we use the experimental flag to support functionality such as string interpolation
+# Start Cake.
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun -experimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun $ScriptArgs"
 exit $LASTEXITCODE

--- a/seed.ps1
+++ b/seed.ps1
@@ -19,8 +19,6 @@ The build script to execute.
 The build script target to run.
 .PARAMETER Migration
 The service migrations to run.
-.PARAMETER Experimental
-Tells Cake to use the latest Roslyn release.
 .PARAMETER WhatIf
 Performs a dry run of the build script.
 No tasks will be executed.
@@ -40,7 +38,6 @@ http://cakebuild.net
 Param(
     [string]$Script = "seed.cake",
     [string]$Target = "Default",
-    [switch]$Experimental,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,
     [switch]$Mono,
@@ -92,13 +89,6 @@ $UseMono = "";
 if($Mono.IsPresent) {
     Write-Verbose -Message "Using the Mono based scripting engine."
     $UseMono = "-mono"
-}
-
-# Should we use the new Roslyn?
-$UseExperimental = "";
-if($Experimental.IsPresent -and !($Mono.IsPresent)) {
-    Write-Verbose -Message "Using experimental version of Roslyn."
-    $UseExperimental = "-experimental"
 }
 
 # Is this a dry run?
@@ -177,7 +167,7 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
-# Start Cake - we use the experimental flag to support functionality such as string interpolation
+# Start Cake.
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun -experimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" $UseMono $UseDryRun $ScriptArgs"
 exit $LASTEXITCODE


### PR DESCRIPTION
Removing the experimental flag, as it is no longer required
All tests pass bar deletions, will look at a fix later