### PR TITLE
Migration performance improvements no bulk executor

### DIFF
--- a/Cake.DocumentDb/Cake.DocumentDb.csproj
+++ b/Cake.DocumentDb/Cake.DocumentDb.csproj
@@ -123,6 +123,7 @@
     <Compile Include="DocumentDbMigrationSettings.cs" />
     <Compile Include="SqlDatabaseConnectionSettings.cs" />
     <Compile Include="StorageConnectionSettings.cs" />
+    <Compile Include="WriteSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Cake.DocumentDb/Cake.DocumentDb.csproj
+++ b/Cake.DocumentDb/Cake.DocumentDb.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Migration\SqlStatement.cs" />
     <Compile Include="Operations\Deletions.cs" />
     <Compile Include="Operations\Hydrations.cs" />
+    <Compile Include="Requests\TaskBuffer.cs" />
     <Compile Include="Seed\EmbeddedDocumentSeed.cs" />
     <Compile Include="Factories\ClientFactory.cs" />
     <Compile Include="Database\ICreateDocumentDatabase.cs" />

--- a/Cake.DocumentDb/Cake.DocumentDb.nuspec
+++ b/Cake.DocumentDb/Cake.DocumentDb.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Cake.DocumentDb</id>
-    <version>7.2.0</version>
+    <version>7.3.0</version>
     <title>$title$</title>
     <authors>jonathan.stowell</authors>
     <owners>Bud Systems Limited</owners>

--- a/Cake.DocumentDb/ConnectionSettings.cs
+++ b/Cake.DocumentDb/ConnectionSettings.cs
@@ -4,5 +4,6 @@
     {
         public string Endpoint { get; set; }
         public string Key { get; set; }
+        public WriteSettings Write { get; set; }
     }
 }

--- a/Cake.DocumentDb/Factories/ClientFactory.cs
+++ b/Cake.DocumentDb/Factories/ClientFactory.cs
@@ -35,7 +35,7 @@ namespace Cake.DocumentDb.Factories
         }
 
         // https://github.com/Azure/azure-cosmos-dotnet-v2/blob/master/samples/documentdb-benchmark/Program.cs
-        public IDocumentClient GetClientOptimistedForWrite()
+        public IDocumentClient GetClientOptimisedForWrite()
         {
             return new DocumentClient(
                 new Uri(settings.Endpoint),

--- a/Cake.DocumentDb/Factories/ClientFactory.cs
+++ b/Cake.DocumentDb/Factories/ClientFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Documents.Client.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
@@ -26,9 +27,31 @@ namespace Cake.DocumentDb.Factories
                 {
                     ConnectionMode = ConnectionMode.Gateway,
                     ConnectionProtocol = Protocol.Https
-                }).AsReliable(new FixedInterval(
-                    15,
-                    TimeSpan.FromSeconds(200)));
+                })
+                .AsReliable(
+                    new FixedInterval(
+                        15,
+                        TimeSpan.FromSeconds(200)));
+        }
+
+        // https://github.com/Azure/azure-cosmos-dotnet-v2/blob/master/samples/documentdb-benchmark/Program.cs
+        public IDocumentClient GetClientOptimistedForWrite()
+        {
+            return new DocumentClient(
+                new Uri(settings.Endpoint),
+                settings.Key,
+                new ConnectionPolicy
+                {
+                    ConnectionMode = ConnectionMode.Direct,
+                    ConnectionProtocol = Protocol.Tcp,
+                    RequestTimeout = new TimeSpan(1, 0, 0),
+                    MaxConnectionLimit = 1000,
+                    RetryOptions = new RetryOptions
+                    {
+                        MaxRetryAttemptsOnThrottledRequests = 10,
+                        MaxRetryWaitTimeInSeconds = 60
+                    }
+                });
         }
     }
 }

--- a/Cake.DocumentDb/Requests/DocumentOperations.cs
+++ b/Cake.DocumentDb/Requests/DocumentOperations.cs
@@ -31,7 +31,7 @@ namespace Cake.DocumentDb.Requests
         public DocumentOperations(ClientFactory clientFactory, CollectionOperations collectionOperations)
         {
             this.client = clientFactory.GetClient();
-            this.clientOptimisedForWrite = clientFactory.GetClientOptimistedForWrite();
+            this.clientOptimisedForWrite = clientFactory.GetClientOptimisedForWrite();
             this.collectionOperations = collectionOperations;
         }
 

--- a/Cake.DocumentDb/Requests/DocumentOperations.cs
+++ b/Cake.DocumentDb/Requests/DocumentOperations.cs
@@ -211,7 +211,7 @@ namespace Cake.DocumentDb.Requests
                 .AsEnumerable()
                 .FirstOrDefault();
 
-            var taskCount = 5;
+            var taskCount = 4;
             if (offer == null)
             {
                 context.Log.Write(Verbosity.Normal, LogLevel.Warning, $"Could not determine current throughput, taskCount defaulted to {taskCount}");

--- a/Cake.DocumentDb/Requests/TaskBuffer.cs
+++ b/Cake.DocumentDb/Requests/TaskBuffer.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Cake.DocumentDb.Requests
+{
+    public class TaskBuffer
+    {
+        private readonly int count;
+        private readonly List<Task> buffer;
+
+        public TaskBuffer(int count)
+        {
+            this.count = count;
+            buffer = new List<Task>(count);
+        }
+
+        public bool IsEmpty()
+        {
+            return buffer.Count == 0;
+        }
+
+        public bool IsFull()
+        {
+            return buffer.Count >= count;
+        }
+
+        public void Add(Task task)
+        {
+            if (IsFull())
+                throw new InvalidOperationException("Buffer is full");
+
+            buffer.Add(task);
+        }
+
+        public async Task ExecuteInParallel()
+        {
+            if (IsEmpty())
+                return;
+
+            await Task.WhenAll(buffer);
+            buffer.Clear();
+        }
+    }
+}

--- a/Cake.DocumentDb/WriteSettings.cs
+++ b/Cake.DocumentDb/WriteSettings.cs
@@ -1,0 +1,16 @@
+﻿namespace Cake.DocumentDb
+{
+    public class WriteSettings
+    {
+        public double ThroughputFactor { get; set; }
+        public int MinTaskCount { get; set; }
+        public int MaxTaskCount { get; set; }
+
+        public static WriteSettings Default = new WriteSettings
+        {
+            ThroughputFactor = 0.01,
+            MinTaskCount = 1,
+            MaxTaskCount = 250
+        };
+    }
+}


### PR DESCRIPTION
Analysis of the migrations showed that the bulk of the time was spent upserting the document after it was mutated in the Migration/SqlMigration/DocumentMigration/DataMigration's Map method. Changes have been made to improve the performance of the DocumentOperations.PerformTask method to reduce the bottleneck.

Ideally we would have used the [bulk executor library](https://docs.microsoft.com/en-us/azure/cosmos-db/bulk-executor-overview) for this, but issues with dependencies render it's use too challenging.